### PR TITLE
Maint/php version update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .php_cs
 .php_cs.cache
 .phpunit.result.cache
+.phpunit.cache
 build
 composer.lock
 coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to `laravel-feedmaker` will be documented in this file.
 
+## 1.0.8 - 2026-08-05
+
+- enhancement: Add compatibility for PHP 8.5 and Laravel 13
+- enhancement: Modernize test configuration and PHP type hints
+
 ## 1.0.7 - 2026-08-04
 
 - enhancement: Add comprehensive Pest test suite

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to `laravel-feedmaker` will be documented in this file.
 
 ## 1.0.8 - 2026-08-05
 
+- enhancement: Replace archived `fabpot/goutte` with Laravel Http client and Symfony DomCrawler
 - enhancement: Add compatibility for PHP 8.5 and Laravel 13
 - enhancement: Modernize test configuration and PHP type hints
 

--- a/composer.json
+++ b/composer.json
@@ -19,17 +19,17 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.2",
         "fabpot/goutte": "^4.0",
         "masterminds/html5": "^2.7",
-        "spatie/laravel-package-tools": "^1.12"
+        "spatie/laravel-package-tools": "^1.16"
     },
     "require-dev": {
-        "guzzlehttp/guzzle": "^7.0",
-        "nunomaduro/collision": "^7.0",
-        "orchestra/testbench": "^8.0",
-        "pestphp/pest": "^2.0",
-        "pestphp/pest-plugin-laravel": "^2.0"
+        "guzzlehttp/guzzle": "^7.8",
+        "nunomaduro/collision": "^8.1",
+        "orchestra/testbench": "^9.0 || ^10.0 || ^11.0",
+        "pestphp/pest": "^3.0",
+        "pestphp/pest-plugin-laravel": "^3.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,10 @@
     ],
     "require": {
         "php": "^8.2",
-        "fabpot/goutte": "^4.0",
         "masterminds/html5": "^2.7",
-        "spatie/laravel-package-tools": "^1.16"
+        "spatie/laravel-package-tools": "^1.16",
+        "symfony/css-selector": "^6.4 || ^7.0",
+        "symfony/dom-crawler": "^6.4 || ^7.0"
     },
     "require-dev": {
         "guzzlehttp/guzzle": "^7.8",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,12 +3,8 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
     backupGlobals="false"
-    backupStaticAttributes="false"
     bootstrap="vendor/autoload.php"
     colors="true"
-    convertErrorsToExceptions="true"
-    convertNoticesToExceptions="true"
-    convertWarningsToExceptions="true"
     processIsolation="false"
     stopOnFailure="false"
     executionOrder="random"
@@ -16,23 +12,18 @@
     failOnRisky="true"
     failOnEmptyTestSuite="true"
     beStrictAboutOutputDuringTests="true"
-    verbose="true"
+    cacheDirectory=".phpunit.cache"
 >
     <testsuites>
         <testsuite name="ChrisHardie Test Suite">
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <coverage>
+    <source>
         <include>
             <directory suffix=".php">./src</directory>
         </include>
-        <report>
-            <html outputDirectory="build/coverage"/>
-            <text outputFile="build/coverage.txt"/>
-            <clover outputFile="build/logs/clover.xml"/>
-        </report>
-    </coverage>
+    </source>
     <logging>
         <junit outputFile="build/report.junit.xml"/>
     </logging>

--- a/src/Commands/FeedmakerCommand.php
+++ b/src/Commands/FeedmakerCommand.php
@@ -38,7 +38,7 @@ class FeedmakerCommand extends Command
      *
      * @return int
      */
-    public function handle()
+    public function handle(): int
     {
         if (! empty($this->argument('class_name'))) {
             $sources = Source::where('class_name', $this->argument('class_name'))->get();
@@ -66,5 +66,7 @@ class FeedmakerCommand extends Command
                 }
             }
         }
+
+        return self::SUCCESS;
     }
 }

--- a/src/Exceptions/SourceNotCrawlable.php
+++ b/src/Exceptions/SourceNotCrawlable.php
@@ -12,7 +12,7 @@ class SourceNotCrawlable extends Exception
 {
     protected Source $source;
 
-    public function __construct($message, $code, $previousException, $source)
+    public function __construct(string $message, int $code = 0, ?\Throwable $previousException = null, ?Source $source = null)
     {
         parent::__construct($message, $code, $previousException);
         $this->source = $source;
@@ -39,7 +39,7 @@ class SourceNotCrawlable extends Exception
         $this->source->update([
             'fail_count' => $new_fail_count,
             'last_fail_at' => Carbon::now(),
-            'last_fail_reason' => $this->message,
+            'last_fail_reason' => $this->getMessage(),
             'next_check_after' => Carbon::now()->addMinutes(3 ** $new_fail_count),
         ]);
 

--- a/src/Sources/BaseSource.php
+++ b/src/Sources/BaseSource.php
@@ -4,13 +4,13 @@ namespace ChrisHardie\Feedmaker\Sources;
 
 use ChrisHardie\Feedmaker\Exceptions\SourceNotCrawlable;
 use ChrisHardie\Feedmaker\Models\Source;
-use Symfony\Component\DomCrawler\Crawler;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Facades\View;
 use Illuminate\Support\Str;
+use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\DomCrawler\UriResolver;
 
 abstract class BaseSource

--- a/src/Sources/BaseSource.php
+++ b/src/Sources/BaseSource.php
@@ -4,7 +4,7 @@ namespace ChrisHardie\Feedmaker\Sources;
 
 use ChrisHardie\Feedmaker\Exceptions\SourceNotCrawlable;
 use ChrisHardie\Feedmaker\Models\Source;
-use Goutte\Client;
+use Symfony\Component\DomCrawler\Crawler;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
@@ -34,7 +34,7 @@ abstract class BaseSource
         }
 
         try {
-            return HTTP::get($url);
+            return Http::get($url);
         } catch (\Exception $e) {
             throw new SourceNotCrawlable(
                 'Problem running GET request: ' . $e->getMessage(),
@@ -48,10 +48,10 @@ abstract class BaseSource
     /**
      * @param Source $source
      * @param null   $url Optional URL to override default source URL
-     * @return \Symfony\Component\DomCrawler\Crawler|null
+     * @return Crawler|null
      * @throws SourceNotCrawlable
      */
-    public function getCrawler(Source $source, $url = null): ?\Symfony\Component\DomCrawler\Crawler
+    public function getCrawler(Source $source, $url = null): ?Crawler
     {
         if (empty($source->source_url) && empty($url)) {
             return null;
@@ -62,9 +62,9 @@ abstract class BaseSource
         }
 
         try {
-            $client = new Client();
+            $response = Http::get($url);
 
-            return $client->request('GET', $url);
+            return new Crawler($response->body(), $url);
         } catch (\Exception $e) {
             throw new SourceNotCrawlable(
                 'Problem running GET request: ' . $e->getMessage(),

--- a/tests/BaseSourceTest.php
+++ b/tests/BaseSourceTest.php
@@ -62,6 +62,20 @@ test('getUrl throws SourceNotCrawlable on failure', function () {
         ->toThrow(SourceNotCrawlable::class);
 });
 
+test('it can get crawler using http facade', function () {
+    Http::fake([
+        'http://example.com' => Http::response('<html><body><h1>Test</h1></body></html>', 200),
+    ]);
+
+    $source = new Source(['source_url' => 'http://example.com']);
+    $baseSource = new TestBaseSource();
+
+    $crawler = $baseSource->getCrawler($source);
+
+    expect($crawler)->toBeInstanceOf(\Symfony\Component\DomCrawler\Crawler::class)
+        ->and($crawler->filter('h1')->text())->toBe('Test');
+});
+
 test('it returns correct last updated string', function () {
     $items = RssItemCollection::make([
         ['pubDate' => Carbon::parse('2023-01-01 10:00:00')],

--- a/tests/temp/testsource.rss
+++ b/tests/temp/testsource.rss
@@ -2,9 +2,9 @@
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
     <channel>
         <atom:link href="http://localhost" rel="self" type="application/rss+xml" />
-        <title><![CDATA[Unde quia et suscipit molestias voluptas ut dicta et.]]></title>
+        <title><![CDATA[Fuga ea et consequatur sapiente quaerat quod eius.]]></title>
         <link><![CDATA[http://localhost]]></link>
-        <description><![CDATA[Unde quia et suscipit molestias voluptas ut dicta et.]]></description>
+        <description><![CDATA[Fuga ea et consequatur sapiente quaerat quod eius.]]></description>
         <pubDate></pubDate>
             </channel>
 </rss>

--- a/tests/temp/testsource.rss
+++ b/tests/temp/testsource.rss
@@ -2,9 +2,9 @@
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
     <channel>
         <atom:link href="http://localhost" rel="self" type="application/rss+xml" />
-        <title><![CDATA[Libero repudiandae voluptate non eos.]]></title>
+        <title><![CDATA[Unde quia et suscipit molestias voluptas ut dicta et.]]></title>
         <link><![CDATA[http://localhost]]></link>
-        <description><![CDATA[Libero repudiandae voluptate non eos.]]></description>
+        <description><![CDATA[Unde quia et suscipit molestias voluptas ut dicta et.]]></description>
         <pubDate></pubDate>
             </channel>
 </rss>


### PR DESCRIPTION
- enhancement: Replace archived `fabpot/goutte` with Laravel Http client and Symfony DomCrawler
- enhancement: Add compatibility for PHP 8.5 and Laravel 13
- enhancement: Modernize test configuration and PHP type hints